### PR TITLE
First abs build [non-defaults]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+aggregate_check: false
+upload_channels:
+  - sfe1ed40
+  - services
+channels:
+  - sfe1ed40
+  - services

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "opentelemetry-proto" %}
 {% set version = "1.12.0" %}
-
+{% set sha256 = "c7f3f2dab9060769ac3ca67b147a0433d7326d5622eed6ef8039afebd80591e3" %}
 
 package:
   name: {{ name|lower }}
@@ -8,20 +8,23 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry-proto-{{ version }}.tar.gz
-  sha256: c7f3f2dab9060769ac3ca67b147a0433d7326d5622eed6ef8039afebd80591e3
+  sha256: {{ sha256 }}
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  # noarch: python
+  skip: true  # [py<36]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
-    - protobuf ~=3.13
-    - python >=3.6
+    - protobuf >=3.13,<4
+    - python
 
 test:
   imports:
@@ -33,10 +36,18 @@ test:
     - pip
 
 about:
+  summary: OpenTelemetry Python / Proto
   home: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-proto
-  summary: OpenTelemetry Python Proto
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
+  doc_source_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs
+  description: |-
+    OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
+    Observability framework for instrumenting, generating, collecting, and exporting
+    telemetry data such as traces, metrics, logs. As an industry-standard
+    it is natively supported by a number of vendors.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Note: this is not a defaults channel build

- Remove noarch
- Replace python pin with skip
- Clean up protobuf spec
- Normalized metadata cross all opentelemetry packages