### PR TITLE
[PKG-4250] Update to 1.23.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
-aggregate_check: false
 upload_channels:
   - sfe1ed40
-  - services
-channels:
-  - sfe1ed40
-  - services

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,8 @@ source:
 
 build:
   number: 0
-  # noarch: python
-  skip: true  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - hatchling
   run:
-    - protobuf >=3.19,<4
+    - protobuf >=3.19,<5
     - python
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - hatchling
   run:
-    - protobuf >=3.13,<4
+    - protobuf >=3.19,<4
     - python
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "opentelemetry-proto" %}
-{% set version = "1.12.0" %}
-{% set sha256 = "c7f3f2dab9060769ac3ca67b147a0433d7326d5622eed6ef8039afebd80591e3" %}
+{% set version = "1.23.0" %}
+{% set sha256 = "e6aaf8b7ace8d021942d546161401b83eed90f9f2cc6f13275008cea730e4651" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,7 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs
+  doc_url: https://opentelemetry-python.readthedocs.io
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry-proto-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_proto-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,7 @@ requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
+    - hatchling
   run:
     - protobuf >=3.13,<4
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ about:
   license_family: Apache
   license_file: LICENSE
   doc_url: https://opentelemetry-python.readthedocs.io
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-proto
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ about:
   license_family: Apache
   license_file: LICENSE
   doc_url: https://opentelemetry-python.readthedocs.io
-  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-proto
+  dev_url: https://github.com/open-telemetry/opentelemetry-python
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting


### PR DESCRIPTION
opentelemetry-proto 1.23.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4250](https://anaconda.atlassian.net/browse/PKG-4250) 
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python/tree/v1.23.0/opentelemetry-proto)
- Upstream [changelog](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.23.0) / [diff](https://github.com/open-telemetry/opentelemetry-python/compare/v1.15.0...v1.23.0)

### Explanation of changes:

- No tests provided by upstream. The only test in the provided `tests` directory only checks if the module is installed.
- OSX builds failing due to ongoing http error with osx builders

[PKG-4250]: https://anaconda.atlassian.net/browse/PKG-4250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ