### PR TITLE
Version 1.26.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "opentelemetry-proto" %}
-{% set version = "1.23.0" %}
-{% set sha256 = "e6aaf8b7ace8d021942d546161401b83eed90f9f2cc6f13275008cea730e4651" %}
+{% set version = "1.27.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_proto-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 33c9345d91dafd8a74fc3d7576c5a38f18b7fdf8d02983ac67485386132aedd6
+  patches:
+    # added to avoid pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
+    - patches/0000-fix-classifier-clash-in-pyproject.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_proto-{{ version }}.tar.gz
-  sha256: 33c9345d91dafd8a74fc3d7576c5a38f18b7fdf8d02983ac67485386132aedd6
+  sha256: c5c18796c0cab3751fc3b98dee53855835e90c0422924b484432ac852d93dc1e
   patches:
     # added to avoid pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
     - patches/0000-fix-classifier-clash-in-pyproject.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-proto" %}
-{% set version = "1.27.0" %}
+{% set version = "1.26.0" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,9 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  build:
+    - patch # [not win]
+    - m2-patch  # [win]
   host:
     - pip
     - python
@@ -50,5 +53,7 @@ about:
     it is natively supported by a number of vendors.
 
 extra:
+  skip-lints:
+    - invalid_url
   recipe-maintainers:
     - mariusvniekerk

--- a/recipe/patches/0000-fix-classifier-clash-in-pyproject.patch
+++ b/recipe/patches/0000-fix-classifier-clash-in-pyproject.patch
@@ -1,0 +1,10 @@
+--- pyproject.toml	2024-08-27 12:14:39.349359424 +0100
++++ "pyproject copy.toml"	2024-08-30 13:34:00.966488250 +0100
+@@ -14,7 +14,6 @@
+ ]
+ classifiers = [
+   "Development Status :: 5 - Production/Stable",
+-  "Framework :: OpenTelemetry",
+   "Intended Audience :: Developers",
+   "License :: OSI Approved :: Apache Software License",
+   "Programming Language :: Python",


### PR DESCRIPTION
opentelemetry-proto 1.27

**Destination channel:** defaults

### Links

- [PKG-2426](https://anaconda.atlassian.net/browse/PKG-2426) 
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python/tree/d84fc6cb9425c2f8c42d528108f651e527d81ef5/opentelemetry-proto)
- [Upstream changelog/diff](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.26.0)
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- sha, classifier patch, version


[PKG-2426]: https://anaconda.atlassian.net/browse/PKG-2426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ