### PR TITLE
opentelemetry-proto 1.38.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-proto" %}
-{% set version = "1.37.0" %}
+{% set version = "1.38.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://github.com/open-telemetry/{{ name.split('-')[0] }}-python/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 57003973bfcb44e111998f6a4c8f7b33e801fe5a9989afcc0c8ee46fd17310ef
+  sha256: c7e941a92e52dc876d60177a81d4d44951a06a70f324a5ccfd956a18725885b9
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install ./{{ name }} -vv --no-deps --no-build-isolation
   skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install ./{{ name }} -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -47,18 +47,18 @@ test:
     - packaging >=24.0
 
 about:
-  summary: OpenTelemetry Python / Proto
   home: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-proto
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  doc_url: https://opentelemetry-python.readthedocs.io
-  dev_url: https://github.com/open-telemetry/opentelemetry-python
+  summary: OpenTelemetry Python / Proto
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting
     telemetry data such as traces, metrics, logs. As an industry-standard
     it is natively supported by a number of vendors.
+  doc_url: https://opentelemetry-python.readthedocs.io
+  dev_url: https://github.com/open-telemetry/opentelemetry-python
 
 extra:
   skip-lints:


### PR DESCRIPTION
opentelemetry-proto 1.38.0 

**Destination channel:** Defaults

### Links

- [PKG-10841]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python/tree/v1.38.0
- conda_forge:    https://github.com/conda-forge/opentelemetry-proto-feedstock
- pypi:           https://pypi.org/project/opentelemetry-proto/1.38.0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-proto/1.38.0

### Explanation of changes:

- new version number


[PKG-10841]: https://anaconda.atlassian.net/browse/PKG-10841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ