### PR TITLE
opentelemetry-proto 1.40.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,1 @@
 staging_channel_upload_target: otel-1.40.0-staging
-
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
+staging_channel_upload_target: otel-1.40.0-staging
+
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-proto" %}
-{% set version = "1.38.0" %}
+{% set version = "1.40.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/open-telemetry/{{ name.split('-')[0] }}-python/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: c7e941a92e52dc876d60177a81d4d44951a06a70f324a5ccfd956a18725885b9
+  sha256: 8542e1cdfd9faaa931e0c24906855f6a40149e6520177926728532cff4315a94
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,5 @@ about:
   dev_url: https://github.com/open-telemetry/opentelemetry-python
 
 extra:
-  skip-lints:
-    - invalid_url
   recipe-maintainers:
     - mariusvniekerk


### PR DESCRIPTION
opentelemetry-proto 1.40.0

**Destination channel:** defaults (via otel-1.40.0-staging during chain build)

### Links

- [PKG-14559](https://anaconda.atlassian.net/browse/PKG-14559)
- Parent epic: [PKG-13074](https://anaconda.atlassian.net/browse/PKG-13074)
- Blocks: [PKG-14486](https://anaconda.atlassian.net/browse/PKG-14486) (pydantic-ai)
- [PyPI release](https://pypi.org/project/opentelemetry-proto/1.40.0/)

### Explanation of changes:

- Bump opentelemetry-proto 1.38.0 -> 1.40.0.
- Tier 1 (leaf) of the 8-package OTel ecosystem lockstep update; this PR has no inter-OTel deps.

[PKG-14559]: https://anaconda.atlassian.net/browse/PKG-14559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13074]: https://anaconda.atlassian.net/browse/PKG-13074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14486]: https://anaconda.atlassian.net/browse/PKG-14486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ