### PR TITLE
rebuild opentelemetry-proto against protobuf 7 (PKG-15937)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 92b8082f603dbacf2f9175fae57e6c8f07fddb70e6aeff66aeb7a7b310242747
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install ./{{ name }} -vv --no-deps --no-build-isolation
   skip: true  # [py<310]
 
@@ -18,6 +18,7 @@ requirements:
   host:
     - pip
     - python
+    - protobuf 7.35.1
     - hatchling
   run:
     - python


### PR DESCRIPTION
## Version
See recipe/meta.yaml

**Destination channel:** main

### Links
- Jira: https://anaconda.atlassian.net/browse/PKG-15937

### Explanation of changes
- Rebuild opentelemetry-proto 1.43.0 against protobuf 7
- Pin host protobuf 7.35.1 and bump build number for Stage 005